### PR TITLE
Add Kubernetes supported resources fetcher.

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -50,6 +50,13 @@ func TestRun(t *testing.T) {
 						Namespace: "default",
 					},
 				},
+				&v1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{Kind: "ConfigMap"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-configmap",
+						Namespace: "default",
+					},
+				},
 			},
 			expObjects: []string{
 				"Pod:default:fake-pod",
@@ -104,6 +111,10 @@ func TestRun(t *testing.T) {
 				// convert the objects to a list of strings
 				objs := make([]string, len(data.Objects))
 				for i, obj := range data.Objects {
+					if obj.Kind == "ConfigMap" {
+						// Should be filtered by Conf
+						t.Error("ConfigMap should be filtered")
+					}
 					objs[i] = fmt.Sprintf("%s:%s:%s", obj.Kind, obj.Object.Metadata.Namespace, obj.Object.Metadata.Name)
 				}
 

--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -163,7 +163,7 @@ func LoadConfig(
 	conf.FetchPersistentVolumes = parseBool(conf.etcConfig("collector.resources.persistentVolumes"), true)
 	conf.FetchPersistentVolumeClaims = parseBool(conf.etcConfig("collector.resources.persistentVolumeClaims"), true)
 	conf.FetchNamespaces = parseBool(conf.etcConfig("collector.resources.namespaces"), true)
-	conf.FetchConfigMaps = parseBool(conf.etcConfig("collector.resources.confMaps"), true)
+	conf.FetchConfigMaps = parseBool(conf.etcConfig("collector.resources.configMaps"), true)
 	conf.FetchSecrets = parseBool(conf.etcConfig("collector.resources.secrets"), false)
 	conf.FetchDeployments = parseBool(conf.etcConfig("collector.resources.deployments"), true)
 	conf.FetchDaemonSets = parseBool(conf.etcConfig("collector.resources.daemonSets"), true)

--- a/collector/k8stypes/k8stypes.go
+++ b/collector/k8stypes/k8stypes.go
@@ -1,0 +1,99 @@
+package k8stypes
+
+import (
+	"context"
+	"fmt"
+	"github.com/infralight/k8s-collector/collector/config"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Collector is a struct implementing the DataCollector interface. It wraps a
+// Kubernetes API client object.
+type Collector struct {
+	// client object for the Kubernetes API server
+	api kubernetes.Interface
+}
+
+// New creates a new instance of the Collector struct. A Kubernetes API client
+// object must be provided. This can either be a client for a real API server,
+// a fake client from k8s.io/client-go/kubernetes/fake, or any object that
+// implements the kubernetes.Interface interface.
+func New(api kubernetes.Interface) *Collector {
+	return &Collector{
+		api: api,
+	}
+}
+
+// DefaultConfiguration creates a Collector instance with default configuration
+// to connect to a local Kubernetes API Server. When running outside of the
+// Kubernetes cluster, the path to the kubeconfig file must be provided. If
+// empty, the default in-cluster configuration is used.
+func DefaultConfiguration(external string) (
+	collector *Collector,
+	err error,
+) {
+	// Load configuration for the Kubernetes API client. We are either running
+	// from inside the cluster (i.e. inside a pod) or outside of the cluster.
+	var apiConfig *rest.Config
+	if external != "" {
+		apiConfig, err = clientcmd.BuildConfigFromFlags("", external)
+	} else {
+		// Load configuration to connect to the Kubernetes API from within a K8s
+		// cluster
+		apiConfig, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return collector, fmt.Errorf("failed loading Kubernetes configuration: %w", err)
+	}
+
+	// Create a new instance of the Kubernetes API client
+	api, err := kubernetes.NewForConfig(apiConfig)
+	if err != nil {
+		return collector, fmt.Errorf("failed getting K8s client set: %w", err)
+	}
+
+	return New(api), nil
+}
+
+// Source is required by the DataCollector interface to return a name for the
+// collector's source, in this case the K8s API Server.
+func (f *Collector) Source() string {
+	return "K8s API Server"
+}
+
+// Run executes the collector with the provided configuration object, and
+// returns a list of supported resources from the cluster.
+func (f *Collector) Run(ctx context.Context, conf *config.Config) (
+	keyName string,
+	types []interface{},
+	err error,
+) {
+
+	var supportedResources []map[string]interface{}
+
+	apiGroups, err := f.api.Discovery().ServerPreferredResources()
+	if err != nil {
+		return "", nil, err
+	}
+	for _, apiGroup := range apiGroups {
+		if len(apiGroup.APIResources) == 0 {
+			continue
+		}
+		for _, resource := range apiGroup.APIResources {
+			var resourceConf = make(map[string]interface{})
+			resourceConf["kind"] = resource.Kind
+			resourceConf["namespaced"] = resource.Namespaced
+			resourceConf["apiVersion"] = apiGroup.GroupVersion
+			supportedResources = append(supportedResources, resourceConf)
+		}
+	}
+
+	types = make([]interface{}, len(supportedResources))
+	for i, rel := range supportedResources {
+		types[i] = rel
+	}
+
+	return "k8s_types", types, nil
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/infralight/k8s-collector/collector/config"
 	"github.com/infralight/k8s-collector/collector/helm"
 	"github.com/infralight/k8s-collector/collector/k8s"
+	"github.com/infralight/k8s-collector/collector/k8stypes"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -51,6 +52,13 @@ func main() {
 			Msg("Failed loading Kubernetes collector")
 	}
 
+	k8sTypesCollector, err := k8stypes.DefaultConfiguration(*external)
+	if err != nil {
+		logger.Fatal().
+			Err(err).
+			Msg("Failed loading Kubernetes collector")
+	}
+
 	// Load the Helm collector
 	helmCollector, err := helm.DefaultConfiguration(logger.Printf)
 	if err != nil {
@@ -60,7 +68,7 @@ func main() {
 	}
 
 	err = collector.
-		New(clusterID, conf, k8sCollector, helmCollector).
+		New(clusterID, conf, k8sCollector, helmCollector, k8sTypesCollector).
 		Run(context.TODO())
 	if err != nil {
 		logger.Fatal().


### PR DESCRIPTION
Add Kubernetes supported resources fetcher.

As part of the collector process, we wish to fetch the supported resources and their version and namespacing definitions.