### PR TITLE
Refactor collector configuration

### DIFF
--- a/charts/chart/Chart.yaml
+++ b/charts/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: infralight-k8s-collector
 home: https://github.com/infralight/k8s-collector
 description: Infralight's Kubernetes Collector
 type: application
-version: 1.2.2
-appVersion: "1.2.2"
+version: 1.3.0
+appVersion: "1.3.0"

--- a/charts/chart/templates/clusterrole.yaml
+++ b/charts/chart/templates/clusterrole.yaml
@@ -3,17 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.clusterRole.name }}
 
-{{- if or .Values.fetchEverything .Values.collectSecrets }}
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - '*'
-    resources:
-      - '*'
-{{- else }}
 rules:
   - apiGroups:
       - '*'
@@ -22,35 +11,20 @@ rules:
       - list
       - watch
     resources:
-      - clusterroles
-      - ingresses
-      - networkpolicies
-      - daemonsets
-      - deployments
-      - replicasets
-      - cronjobs
-      - jobs
-      - statefulsets
-      - namespaces
-      - nodes
-      - events
-      - services/status
-      - services
-      - serviceaccounts
-      - replicationcontrollers
-      - pods
-      - persistentvolumeclaims
-      - persistentvolumes
-      - configmaps
-      - endpoints
-      - storageclasses
-      - customresourcedefinitions
-      - rollouts
-      - rollouts/status
-      - rollouts/finalizers
-      - analysistemplates
-      - clusteranalysistemplates
-      {{- if or .Values.collectArgoApplications }}
-      - applications
-      {{- end }}
-  {{- end }}
+{{- if .Values.fetchEverything }}
+      - '*'
+{{ else -}}
+      {{ $resources := list "apiservices" "analysistemplates" "clusteranalysistemplates" "clusterroles" "clusterrolebindings" "configmaps" "controllerrevisions" "cronjobs" "csinodes" "customresourcedefinitions" "daemonsets" "deployments" "endpoints" "endpointslices" "flowschemas" "ingresses" "jobs" "leases" "namespaces" "networkpolicies" "nodes" "persistentvolumeclaims" "persistentvolumes" "pods" "priorityclasses" "prioritylevelconfigurations" "replicasets" "replicationcontrollers" "roles" "rolebindings" "rollouts" "rollouts/finalizers" "rollouts/status" "serviceaccounts" "services" "services/status" "statefulsets" "storageclasses" }}
+      {{- range $i, $name := $resources }}
+        {{- if has $name $.Values.removeTypes }}
+          {{- continue -}}
+        {{- end }}
+      - {{ $name }}
+      {{ end -}}
+      {{- range $i, $name := $.Values.addTypes }}
+      - {{ $name }}
+      {{ end -}}
+      {{- if and ($.Values.collectSecrets) (not (has "secrets" $.Values.addTypes)) }}
+      - secrets
+      {{ end -}}
+{{ end -}}

--- a/charts/chart/templates/configmap.yaml
+++ b/charts/chart/templates/configmap.yaml
@@ -3,42 +3,24 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config
 data:
-  endpoint: {{ .Values.apiEndpoint }}
+{{ if .Values.apiEndpoint }}
+  endpoint: {{ quote .Values.apiEndpoint }}
+{{ end }}
   collector.watchNamespace: default
   collector.ignoreNamespaces: |
     kube-system
-  collector.resources.replicationControllers: "true"
-  collector.resources.services: "true"
-  collector.resources.serviceAccounts: "true"
-  collector.resources.pods: "true"
-  collector.resources.nodes: "true"
-  collector.resources.persistentVolumes: "true"
-  collector.resources.persistentVolumeClaims: "true"
-  collector.resources.namespaces: "true"
-  collector.resources.configMaps: "true"
-  collector.resources.deployments: "true"
-  collector.resources.daemonSets: "true"
-  collector.resources.replicaSets: "true"
-  collector.resources.statefulSets: "true"
-  collector.resources.jobs: "true"
-  collector.resources.cronJobs: "true"
-  collector.resources.ingresses: "true"
-  collector.resources.clusterRoles: "true"
-  collector.resources.componentStatuses: "false"
-  collector.resources.flowSchemas: "false"
-  collector.resources.podMetrics: "false"
-{{- if .Values.collectEvents}}
-  collector.resources.events: "true"
-{{- else }}
-  collector.resources.events: "false"
-{{- end }}
-{{- if .Values.collectSecrets}}
-  collector.resources.secrets: "true"
-{{- else }}
-  collector.resources.secrets: "false"
-{{- end }}
-{{- if .Values.overrideUniqueClusterId}}
-  collector.overrideUniqueClusterId: "true"
-{{- else }}
-  collector.overrideUniqueClusterId: "false"
-{{- end }}
+  collector.overrideUniqueClusterId: {{ if .Values.overrideUniqueClusterId }}"true"{{ else }}"false"{{ end }}
+  collector.resources: |
+    {{ $resources := list "apiservices" "analysistemplates" "clusteranalysistemplates" "clusterroles" "clusterrolebindings" "configmaps" "controllerrevisions" "cronjobs" "csinodes" "customresourcedefinitions" "daemonsets" "deployments" "endpoints" "endpointslices" "flowschemas" "ingresses" "jobs" "leases" "namespaces" "networkpolicies" "nodes" "persistentvolumeclaims" "persistentvolumes" "pods" "priorityclasses" "prioritylevelconfigurations" "replicasets" "replicationcontrollers" "roles" "rolebindings" "rollouts" "rollouts/finalizers" "rollouts/status" "serviceaccounts" "services" "services/status" "statefulsets" "storageclasses" }}
+    {{- range $i, $name := $resources }}
+      {{- if has $name $.Values.removeTypes }}
+        {{- continue -}}
+      {{- end }}
+      {{ $name -}}
+    {{ end -}}
+    {{- range $i, $name := $.Values.addTypes }}
+      {{ $name -}}
+    {{ end -}}
+    {{- if and ($.Values.collectSecrets) (not (has "secrets" $.Values.addTypes)) }}
+      secrets
+    {{ end -}}

--- a/charts/chart/values.yaml
+++ b/charts/chart/values.yaml
@@ -1,10 +1,20 @@
+# clusterId is a unique identifier to give the cluster on which the collector
+# runs.
 clusterId: "default"
+overrideUniqueClusterId: false
+
+# schedule is a cron-like value that defines the schedule for the collector's
+# execution. By default, the collector is executed every 15 minutes.
 schedule: "*/15 * * * *"
 
-apiEndpoint: null
+# accessKey and secretKey are the keypair for authenticating against the
+# Firefly API.
 accessKey: null
 secretKey: null
 
+# image defines the name and pull policy for the OCI image of the collector.
+# By default, the tag defaults to the appVersion value in the chart. You can
+# set a specific tag via the "tag" field.
 image:
   repository: infralightio/k8s-collector
   pullPolicy: Always
@@ -24,8 +34,23 @@ resources:
     cpu: "1.0"
     memory: "2048Mi"
 
-collectSecrets: false
-collectEvents: false
-collectArgoApplications: true
-overrideUniqueClusterId: false
+# apiEndpoint is the URL to Firefly's API. Leave empty unless you have a
+# specific reason to change this.
+apiEndpoint: ""
+
+# fetchEverything is a boolean value indicating whether to allow Firefly to
+# fetch all Kubernetes resource types
 fetchEverything: true
+
+# removeTypes accepts a list of resource types that should be removed from the
+# default list of allowed resources.
+removeTypes: []
+
+# addTypes accepts a list of resource types that should be added to the default
+# list of allowed resources. This is mostly useful for CRDs.
+addTypes: []
+
+# DEPRECATED: collectSecrets is a boolean value indicating whether the collector
+# should collect secrets from the cluster. This value is deprecated in favor of
+# the addTypes value.
+collectSecrets: false


### PR DESCRIPTION
A refactor of configuration-related code and template is made, in an
attempt to make the configuration more flexible and easier for our
customers and to fix a few small issues.

1. The "apiEndpoint" chart value is now optional, and defaults to
   Firefly's production API URL, which is added as a constant to
   config.go. The old API URL is automatically recognized and converted
   if necessary.
2. The "useSpecificRoute" value is removed as it was unnecessary and
   undocumented. "apiEndpoint" should be used when configuring the
   collector to work against a different endpoint.
3. Customers can now remove resource types that Firefly collects by
   default via the `--set "removeTypes={x,y,z}"` flag to `helm install`.
4. Customers can now add resource types that Firefly should collect
   apart from the defaults via the `--set "addTypes={x,y,z}"` flag to
   `helm install`.
5. The config.go file is greatly simplified, allowed resources are now
   automatically pushed to a single map, and there is no need to define
   resource types in the file apart from the `DefaultResourceTypes`
   list.
6. When traversing Kubernetes resources, the collector will consult the
   list of allowed resources directly by their plural type name, so a
   map of Kind values is no longer necessary. It also calculated whether
   a resource type is a CRD in a more accurate way.
7. The values.yaml file is supplemented with comments that describe the
   different values that customers can modify.
8. The README.md file is modified with up-to-date and more information.